### PR TITLE
編集＆削除機能実装

### DIFF
--- a/app/assets/stylesheets/shares.scss
+++ b/app/assets/stylesheets/shares.scss
@@ -110,7 +110,6 @@ form {
 
 .error-message {
   font-size: 1.5vw;
-  list-style: circle;
   color: rgb(182, 48, 0);
 }
 
@@ -123,6 +122,21 @@ form {
   width: 20vw;
   color: #ffffff;
   background-color: #424242;
+}
+
+.or-text {
+  margin-bottom: 8vh;
+  text-align: center;
+}
+
+
+.delete-btn {
+  padding: 2vh 4vw;
+  color: #ffffff;
+  background-color: #424242;
+  font-size: 16px;
+  text-align: center;
+  border-radius: 5px;
 }
 
 

--- a/app/assets/stylesheets/shares.scss
+++ b/app/assets/stylesheets/shares.scss
@@ -136,7 +136,7 @@ form {
   background-color: #424242;
   font-size: 16px;
   text-align: center;
-  border-radius: 5px;
+  border-radius: 20px;
 }
 
 

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -1,6 +1,6 @@
 class SharesController < ApplicationController
-  # before_action :set_item, only: [:edit, :update, :destroy]
-  # before_action :authenticate_user!, except: [:index]
+  before_action :set_share, only: [:edit, :update, :destroy]
+  before_action :authenticate_user!, except: [:index]
 
   def index
     @categories = Category.all
@@ -22,19 +22,26 @@ class SharesController < ApplicationController
 
 
   def edit
+    redirect_to root_path if current_user != @share.user
   end
 
   def update
-    @share.update(share_params)
+    if @share.update(share_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   def destroy
-    @share.destroy
+    if current_user != @share.user || @share.destroy
+      redirect_to root_path
+    end
   end
 
 
   private
-  def set_item
+  def set_share
     @share = Share.find(params[:id])
   end
 

--- a/app/views/shares/edit.html.erb
+++ b/app/views/shares/edit.html.erb
@@ -15,7 +15,7 @@
     <%= form_with model: @share, local: true do |f| %>
 
           <div class="submit-form">
-            <p class= "or-text"><%= link_to '削除', share_path(@share.id), method: :delete, class:"delete-btn" %></p>
+            <p class= "or-text"><%= link_to 'Delete', share_path(@share.id), method: :delete, class:"delete-btn" %></p>
             <%= f.submit "Share", class:"submit" %>
           </div>
           <div class="main-form">

--- a/app/views/shares/edit.html.erb
+++ b/app/views/shares/edit.html.erb
@@ -15,7 +15,7 @@
     <%= form_with model: @share, local: true do |f| %>
 
           <div class="submit-form">
-            <p class="error error-messages">コメントは必須です<br>タイトルは必須です<br>URLは必須です<br>カテゴリーは必須です</p>
+            <p class= "or-text"><%= link_to '削除', share_path(@share.id), method: :delete, class:"delete-btn" %></p>
             <%= f.submit "Share", class:"submit" %>
           </div>
           <div class="main-form">


### PR DESCRIPTION
# what
* 投稿内容の編集・削除機能の追加
* 削除ボタン追加
* レイアウト修正
* ログアウト・未登録者はindex以外のページへは直接、遷移できない。
* 他人の投稿した記事の編集ページヘは遷移できない。
# why
* 削除ボタン は shareボタン との差別化を図るためあえて大きさ、形を変更。
* ログアウト・未登録者はindex以外のページに移動しようとするとログインページに遷移する。
* 他人の投稿した記事の編集ページへ移動しようとすると、トップページへ遷移する。
# 機能確認用URL
* 編集機能実行画面　：https://gyazo.com/9b988b99035ead7f51d7950812d234fe
* 削除機能実行画面　：https://gyazo.com/7f924d202e4edf19d33145e8068197ee
* ログアウト・未登録者のindex以外のページへ遷移　：https://gyazo.com/2e9b998823bd39a42b502e1f51664274
* 他人の投稿した記事への編集ページの遷移　：https://gyazo.com/9ffbea0bc8389d5ac3dc9515dd880a12
